### PR TITLE
Use System.Text.Json instead of Newtonsoft

### DIFF
--- a/src/ContainerTagRemover/Configuration/TagRemovalConfig.cs
+++ b/src/ContainerTagRemover/Configuration/TagRemovalConfig.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace ContainerTagRemover.Configuration
 {
@@ -34,7 +34,7 @@ namespace ContainerTagRemover.Configuration
                 using (StreamReader reader = new StreamReader(stream))
                 {
                     string configContent = reader.ReadToEnd();
-                    return JsonConvert.DeserializeObject<TagRemovalConfig>(configContent);
+                    return JsonSerializer.Deserialize<TagRemovalConfig>(configContent);
                 }
             }
             catch (Exception ex)

--- a/src/ContainerTagRemover/Services/AzureContainerRegistryClient.cs
+++ b/src/ContainerTagRemover/Services/AzureContainerRegistryClient.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using ContainerTagRemover.Interfaces;
-using Newtonsoft.Json.Linq;
 
 namespace ContainerTagRemover.Services
 {
@@ -42,9 +42,19 @@ namespace ContainerTagRemover.Services
 
         private static IEnumerable<string> ParseTags(string content)
         {
-            var json = JObject.Parse(content);
-            var tags = json["tags"].ToObject<List<string>>();
-            return tags;
+            using (JsonDocument document = JsonDocument.Parse(content))
+            {
+                JsonElement root = document.RootElement;
+                JsonElement tagsElement = root.GetProperty("tags");
+                var tags = new List<string>();
+
+                foreach (JsonElement tagElement in tagsElement.EnumerateArray())
+                {
+                    tags.Add(tagElement.GetString());
+                }
+
+                return tags;
+            }
         }
     }
 }

--- a/src/ContainerTagRemover/Services/DockerhubClient.cs
+++ b/src/ContainerTagRemover/Services/DockerhubClient.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using ContainerTagRemover.Interfaces;
-using Newtonsoft.Json.Linq;
 
 namespace ContainerTagRemover.Services
 {
@@ -49,9 +49,19 @@ namespace ContainerTagRemover.Services
 
         private static IEnumerable<string> ParseTags(string content)
         {
-            var json = JObject.Parse(content);
-            var tags = json["tags"].ToObject<List<string>>();
-            return tags;
+            using (JsonDocument document = JsonDocument.Parse(content))
+            {
+                JsonElement root = document.RootElement;
+                JsonElement tagsElement = root.GetProperty("tags");
+                var tags = new List<string>();
+
+                foreach (JsonElement tagElement in tagsElement.EnumerateArray())
+                {
+                    tags.Add(tagElement.GetString());
+                }
+
+                return tags;
+            }
         }
     }
 }


### PR DESCRIPTION
Replace `Newtonsoft.Json` with `System.Text.Json` for JSON deserialization and parsing.

* **TagRemovalConfig.cs**
  - Replace `Newtonsoft.Json` with `System.Text.Json` for JSON deserialization.
  - Update `Load` method to use `JsonSerializer.Deserialize` instead of `JsonConvert.DeserializeObject`.

* **AzureContainerRegistryClient.cs**
  - Replace `Newtonsoft.Json.Linq` with `System.Text.Json` for JSON parsing.
  - Update `ParseTags` method to use `JsonDocument` instead of `JObject`.

* **DockerhubClient.cs**
  - Replace `Newtonsoft.Json.Linq` with `System.Text.Json` for JSON parsing.
  - Update `ParseTags` method to use `JsonDocument` instead of `JObject`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaq316/ContainerTagRemover/pull/2?shareId=59bb34b5-f874-4d42-a2f8-c498364c4ae4).