### PR TITLE
Fix build and test GitHub action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,10 +22,10 @@ jobs:
         dotnet-version: 8.0.x
 
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore src/ContainerTagRemover/ContainerTagRemover.sln
 
     - name: Build solution
-      run: dotnet build --no-restore
+      run: dotnet build src/ContainerTagRemover/ContainerTagRemover.sln --no-restore
 
     - name: Run tests
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test src/ContainerTagRemover/ContainerTagRemover.sln --no-build --verbosity normal

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ The configuration file is a JSON file that specifies the number of tags to keep 
 1. Clone the repository:
 
 ```sh
-git clone https://github.com/githubnext/workspace-blank.git
-cd workspace-blank
+git clone https://github.com/jaq316/ContainerTagRemover.git
+cd src/ContainerTagRemover
 ```
 
 2. Build the solution:


### PR DESCRIPTION
Update the GitHub Actions workflow and README.md to fix the MSBUILD error MSB1003 during the "Restore Dependencies" step.

* **.github/workflows/build-and-test.yml**
  - Update the `dotnet restore` command to specify the solution file `src/ContainerTagRemover/ContainerTagRemover.sln`.
  - Update the `dotnet build` command to specify the solution file `src/ContainerTagRemover/ContainerTagRemover.sln`.
  - Update the `dotnet test` command to specify the solution file `src/ContainerTagRemover/ContainerTagRemover.sln`.

* **README.md**
  - Update the `git clone` command to use the correct repository URL.
  - Update the `cd` command to navigate to the correct directory.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaq316/ContainerTagRemover/pull/3?shareId=30e6d819-b8bf-4a3f-bca4-ebfb06e3ed12).