### PR TITLE
Derive registry type from registry URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ dotnet build
 3. Run the tool:
 
 ```sh
-dotnet run --project src/ContainerTagRemover/ContainerTagRemover.csproj -- <registry> <repository> <config-file>
+dotnet run --project src/ContainerTagRemover/ContainerTagRemover.csproj -- <registry-url> <repository> <config-file>
 ```
 
-Replace `<registry>`, `<repository>`, and `<config-file>` with the appropriate values.
+Replace `<registry-url>`, `<repository>`, and `<config-file>` with the appropriate values.
 
 If the configuration file is not specified, the tool will use the default values: Major: 2, Minor: 2.
 


### PR DESCRIPTION
Fixes #9

Update `src/ContainerTagRemover/Program.cs` to derive registry type from registry URL.

* Modify `Main` method to accept `registryUrl` instead of `registry`.
* Update `ConfigureServices` method to parse `registryUrl` and determine the appropriate container registry client.
* Register `AzureContainerRegistryClient` if `registryUrl` contains "azurecr.io".
* Register `DockerhubClient` if `registryUrl` contains "dockerhub".
* Throw an exception for unsupported registry URLs.

Update `README.md` to reflect the new behavior of determining the registry type from the URL.

* Change usage instructions to use `<registry-url>` instead of `<registry>`.
* Update the description to replace `<registry>` with `<registry-url>`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaq316/ContainerTagRemover/pull/10?shareId=7fd53b79-7a6e-4296-9b65-5a216e515589).