### PR TITLE
Track and display removed and kept tags

### DIFF
--- a/src/ContainerTagRemover/Program.cs
+++ b/src/ContainerTagRemover/Program.cs
@@ -59,6 +59,22 @@ namespace ContainerTagRemover
 
             var tagRemovalService = serviceProvider.GetService<TagRemovalService>();
             await tagRemovalService.RemoveOldTagsAsync(image);
+
+            var removedTags = tagRemovalService.GetRemovedTags();
+            Console.WriteLine("Removed Tags:");
+            foreach (var tag in removedTags)
+            {
+                Console.WriteLine(tag);
+            }
+
+            var keptTags = tagRemovalService.GetKeptTags();
+            Console.WriteLine("Kept Tags:");
+            foreach (var tag in keptTags)
+            {
+                Console.WriteLine(tag);
+            }
+
+            Console.WriteLine($"Summary: Removed {removedTags.Count} tags, Kept {keptTags.Count} tags.");
         }
 
         private static void ConfigureServices(IServiceCollection services, string registryUrl, TagRemovalConfig config)

--- a/tests/ContainerTagRemover.Tests/Services/TagRemovalServiceTests.cs
+++ b/tests/ContainerTagRemover.Tests/Services/TagRemovalServiceTests.cs
@@ -175,5 +175,61 @@ namespace ContainerTagRemover.Tests.Services
             result.ShouldContain("2.1.4");
             result.ShouldContain("2.1.5");
         }
+
+        [Fact]
+        public void GetRemovedTags_Should_Return_Correct_List()
+        {
+            // Arrange
+            var repository = "test-repo";
+            var tags = new List<Tag> {
+                new Tag("1.0.0", "digest1"),
+                new Tag("1.0.1", "digest2"),
+                new Tag("1.0.2", "digest3"),
+                new Tag("1.0.3", "digest4"),
+                new Tag("1.0.4", "digest5"),
+                new Tag("1.0.5", "digest6"),
+                new Tag("1.0.6", "digest7"),
+                new Tag("1.0.7", "digest8"),
+            };
+            _mockRegistryClient.Setup(x => x.ListTagsAsync(repository)).ReturnsAsync(tags);
+
+            // Act
+            _tagRemovalService.RemoveOldTagsAsync(repository).Wait();
+            var removedTags = _tagRemovalService.GetRemovedTags();
+
+            // Assert
+            removedTags.ShouldContain("1.0.0");
+            removedTags.ShouldContain("1.0.1");
+            removedTags.ShouldContain("1.0.2");
+            removedTags.ShouldContain("1.0.3");
+            removedTags.ShouldContain("1.0.4");
+            removedTags.ShouldContain("1.0.5");
+        }
+
+        [Fact]
+        public void GetKeptTags_Should_Return_Correct_List()
+        {
+            // Arrange
+            var repository = "test-repo";
+            var tags = new List<Tag> {
+                new Tag("1.0.0", "digest1"),
+                new Tag("1.0.1", "digest2"),
+                new Tag("1.0.2", "digest3"),
+                new Tag("1.0.3", "digest4"),
+                new Tag("1.0.4", "digest5"),
+                new Tag("1.0.5", "digest6"),
+                new Tag("1.0.6", "digest7"),
+                new Tag("1.0.7", "digest8"),
+            };
+            _mockRegistryClient.Setup(x => x.ListTagsAsync(repository)).ReturnsAsync(tags);
+
+            // Act
+            _tagRemovalService.RemoveOldTagsAsync(repository).Wait();
+            var keptTags = _tagRemovalService.GetKeptTags();
+
+            // Assert
+            keptTags.ShouldContain("1.0.6");
+            keptTags.ShouldContain("1.0.7");
+        }
     }
 }


### PR DESCRIPTION
Add functionality to keep track of removed and kept tags and display a summary before the console app exits.

* **TagRemovalService.cs**
  - Add private fields `removedTags` and `keptTags` to keep track of removed and kept tags.
  - Update `RemoveOldTagsAsync` method to log removed and kept tags.
  - Add public methods `GetRemovedTags` and `GetKeptTags` to return the lists of removed and kept tags.

* **Program.cs**
  - Add code to `Main` method to display removed tags and a summary before exit.
  - Retrieve removed and kept tags from `TagRemovalService` and display them.
  - Display a summary of removed vs kept tags.

* **TagRemovalServiceTests.cs**
  - Add tests to verify that removed and kept tags are tracked correctly.
  - Add tests to verify that `GetRemovedTags` and `GetKeptTags` return the correct lists of removed and kept tags.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaq316/ContainerTagRemover/pull/12?shareId=a7f18075-b5b9-4e32-abba-928cd094c539).