### PR TITLE
Add ability to output the list of removed and kept tags to a json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ dotnet build
 3. Run the tool:
 
 ```sh
-dotnet run --project src/ContainerTagRemover/ContainerTagRemover.csproj -- <registry-url> <image> <config-file>
+dotnet run --project src/ContainerTagRemover/ContainerTagRemover.csproj -- <registry-url> <image> <config-file> [--output-file <output-file>]
 ```
 
-Replace `<registry-url>`, `<image>`, and `<config-file>` with the appropriate values.
+Replace `<registry-url>`, `<image>`, and `<config-file>` with the appropriate values. Optionally, specify `<output-file>` to output the list of removed and kept tags to a JSON file.
 
 If the configuration file is not specified, the tool will use the default values: Major: 2, Minor: 2.
 
@@ -111,10 +111,10 @@ dotnet tool install --global --add-source ./nupkg containertagremover
 Once installed, you can use the tool from any directory by running:
 
 ```sh
-containertagremover <registry-url> <image> <config-file>
+containertagremover <registry-url> <image> <config-file> [--output-file <output-file>]
 ```
 
-Replace `<registry-url>`, `<image>`, and `<config-file>` with the appropriate values.
+Replace `<registry-url>`, `<image>`, and `<config-file>` with the appropriate values. Optionally, specify `<output-file>` to output the list of removed and kept tags to a JSON file.
 
 If the configuration file is not specified, the tool will use the default values: Major: 2, Minor: 2.
 

--- a/tests/ContainerTagRemover.Tests/ProgramTests.cs
+++ b/tests/ContainerTagRemover.Tests/ProgramTests.cs
@@ -8,11 +8,93 @@ using ContainerTagRemover.Configuration;
 using ContainerTagRemover.Interfaces;
 using ContainerTagRemover.Services;
 using Microsoft.Extensions.DependencyInjection;
+using System.Text.Json;
 
 namespace ContainerTagRemover.Tests
 {
     public class ProgramTests
     {
-       
+        [Fact]
+        public async Task Main_Should_Write_Output_To_File_When_OutputFile_Parameter_Is_Provided()
+        {
+            // Arrange
+            var registryUrl = "https://test.azurecr.io";
+            var image = "test-image";
+            var configFilePath = "test-config.json";
+            var outputFilePath = "output.json";
+
+            var args = new[] { registryUrl, image, configFilePath, "--output-file", outputFilePath };
+
+            var mockRegistryClient = new Mock<IContainerRegistryClient>();
+            mockRegistryClient.Setup(x => x.AuthenticateAsync(It.IsAny<System.Threading.CancellationToken>())).Returns(Task.CompletedTask);
+            mockRegistryClient.Setup(x => x.ListTagsAsync(It.IsAny<string>())).ReturnsAsync(new[] { new Tag("1.0.0", "digest1"), new Tag("1.0.1", "digest2") });
+            mockRegistryClient.Setup(x => x.DeleteTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton(mockRegistryClient.Object);
+            serviceCollection.AddSingleton(new TagRemovalConfig { Major = 2, Minor = 2 });
+            serviceCollection.AddSingleton<TagRemovalService>();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var serviceScopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
+
+            var mockServiceScopeFactory = new Mock<IServiceScopeFactory>();
+            mockServiceScopeFactory.Setup(x => x.CreateScope()).Returns(serviceScopeFactory.CreateScope());
+
+            var mockServiceProvider = new Mock<IServiceProvider>();
+            mockServiceProvider.Setup(x => x.GetService(typeof(IServiceScopeFactory))).Returns(mockServiceScopeFactory.Object);
+
+            // Act
+            await Program.Main(args);
+
+            // Assert
+            Assert.True(File.Exists(outputFilePath));
+
+            var outputContent = await File.ReadAllTextAsync(outputFilePath);
+            var output = JsonSerializer.Deserialize<dynamic>(outputContent);
+
+            Assert.NotNull(output);
+            Assert.Equal(2, ((JsonElement)output).GetProperty("RemovedTags").GetArrayLength());
+            Assert.Equal(0, ((JsonElement)output).GetProperty("KeptTags").GetArrayLength());
+
+            // Cleanup
+            File.Delete(outputFilePath);
+        }
+
+        [Fact]
+        public async Task Main_Should_Not_Write_Output_To_File_When_OutputFile_Parameter_Is_Not_Provided()
+        {
+            // Arrange
+            var registryUrl = "https://test.azurecr.io";
+            var image = "test-image";
+            var configFilePath = "test-config.json";
+
+            var args = new[] { registryUrl, image, configFilePath };
+
+            var mockRegistryClient = new Mock<IContainerRegistryClient>();
+            mockRegistryClient.Setup(x => x.AuthenticateAsync(It.IsAny<System.Threading.CancellationToken>())).Returns(Task.CompletedTask);
+            mockRegistryClient.Setup(x => x.ListTagsAsync(It.IsAny<string>())).ReturnsAsync(new[] { new Tag("1.0.0", "digest1"), new Tag("1.0.1", "digest2") });
+            mockRegistryClient.Setup(x => x.DeleteTagAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton(mockRegistryClient.Object);
+            serviceCollection.AddSingleton(new TagRemovalConfig { Major = 2, Minor = 2 });
+            serviceCollection.AddSingleton<TagRemovalService>();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var serviceScopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
+
+            var mockServiceScopeFactory = new Mock<IServiceScopeFactory>();
+            mockServiceScopeFactory.Setup(x => x.CreateScope()).Returns(serviceScopeFactory.CreateScope());
+
+            var mockServiceProvider = new Mock<IServiceProvider>();
+            mockServiceProvider.Setup(x => x.GetService(typeof(IServiceScopeFactory))).Returns(mockServiceScopeFactory.Object);
+
+            // Act
+            await Program.Main(args);
+
+            // Assert
+            Assert.False(File.Exists("output.json"));
+        }
     }
 }


### PR DESCRIPTION
Add ability to output the list of removed and kept tags to a JSON file using an optional CLI parameter `--output-file`.

* **Program.cs**
  - Add a new optional parameter `--output-file` to the `args` array.
  - Add logic to handle the `--output-file` parameter and set the output file path.
  - Add logic to write the list of removed and kept tags to the specified JSON file if the `--output-file` parameter is provided.

* **README.md**
  - Add a description of the new `--output-file` parameter and its usage.
  - Update the example command to include the `--output-file` parameter.

* **ProgramTests.cs**
  - Add unit tests to verify the functionality of the `--output-file` parameter.
  - Add unit tests to verify that the list of removed and kept tags is correctly written to the specified JSON file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaq316/ContainerTagRemover/pull/13?shareId=fa729989-3b0f-4878-9496-abc3e76b7640).