### PR TITLE
Fix build solution step in GitHub workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,11 +15,19 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 8.0.x
+
+    - name: Install GitVersion
+      run: dotnet tool install -g GitVersion.Tool
+
+    - name: Use GitVersion to generate version
+      run: gitversion /output json /showvariable FullSemVer
 
     - name: Restore dependencies
       run: dotnet restore src/ContainerTagRemover/ContainerTagRemover.sln
@@ -36,12 +44,6 @@ jobs:
     - name: Publish tool
       if: github.event_name != 'pull_request'
       run: dotnet nuget push ./nupkg/*.nupkg --source nuget.org --api-key ${{ secrets.NUGET_API_KEY }}
-
-    - name: Install GitVersion
-      run: dotnet tool install -g GitVersion.Tool
-
-    - name: Use GitVersion to generate version
-      run: gitversion /output json /showvariable FullSemVer
 
     - name: Create GitHub release
       if: github.event_name != 'pull_request'

--- a/src/ContainerTagRemover/ContainerTagRemover.csproj
+++ b/src/ContainerTagRemover/ContainerTagRemover.csproj
@@ -12,10 +12,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
-    <PackageReference Include="GitVersion.MsBuild" Version="6.1.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
Fix the build solution step in the GitHub workflow by addressing the shallow clone issue.

* **.github/workflows/build-and-test.yml**
  - Add `fetch-depth: 0` to the `actions/checkout@v2` step to ensure a full clone.
  - Move the `Install GitVersion` and `Use GitVersion to generate version` steps before the `Build solution` step.

* **src/ContainerTagRemover/ContainerTagRemover.csproj**
  - Remove the `GitVersion.MsBuild` package reference.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaq316/ContainerTagRemover/pull/15?shareId=1d7ad15e-0594-4d43-b3aa-1f85bf3e4034).