### PR TITLE
Add the namespace `jaq316` to the nuget package

### DIFF
--- a/src/ContainerTagRemover/ContainerTagRemover.csproj
+++ b/src/ContainerTagRemover/ContainerTagRemover.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <RootNamespace>ContainerTagRemover</RootNamespace>
+    <RootNamespace>jaq316.ContainerTagRemover</RootNamespace>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>containertagremover</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/src/ContainerTagRemover/ContainerTagRemover.nuspec
+++ b/src/ContainerTagRemover/ContainerTagRemover.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>ContainerTagRemover</id>
+    <id>jaq316.ContainerTagRemover</id>
     <version>1.0.0</version>
     <authors>jaq316</authors>
     <owners>jaq316</owners>


### PR DESCRIPTION
Add the namespace `jaq316` to the nuget package.

* **`src/ContainerTagRemover/ContainerTagRemover.csproj`**
  - Set the `RootNamespace` property to `jaq316.ContainerTagRemover`.

* **`src/ContainerTagRemover/ContainerTagRemover.nuspec`**
  - Set the `id` field to `jaq316.ContainerTagRemover`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaq316/ContainerTagRemover/pull/18?shareId=4bb678e8-fed1-4157-8181-46283d8051af).