### PR TITLE
Fix GitHub release task by adding required inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,4 @@ The GitVersion configuration file (`gitversion.yml`) is included in the reposito
 
 ### GitHub Workflow
 
-The GitHub workflow file (`.github/workflows/build-and-test.yml`) has been updated to include steps for installing and using GitVersion to generate release versions. The workflow will automatically create a new release whenever the main branch is updated.
+The GitHub workflow file (`.github/workflows/build-and-test.yml`) has been updated to include steps for installing and using GitVersion to generate release versions. The workflow will automatically create a new release whenever the main branch is updated. The `Create GitHub release` step now includes the `tag_name` input with the value `${{ steps.gitversion.outputs.FullSemVer }}` and the `release_name` input with the value `Release ${{ steps.gitversion.outputs.FullSemVer }}`.


### PR DESCRIPTION
Update GitHub workflow to include `tag_name` and `release_name` inputs in `Create GitHub release` step.

* Modify `.github/workflows/build-and-test.yml` to add `tag_name` input with the value `${{ steps.gitversion.outputs.FullSemVer }}`
* Add `release_name` input with the value `Release ${{ steps.gitversion.outputs.FullSemVer }}`
* Update `README.md` to reflect the changes made to the `Create GitHub release` step in the GitHub workflow

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaq316/ContainerTagRemover/pull/19?shareId=3e8cfe7e-bafd-4eb0-ae8d-312fa6a190bc).