### PR TITLE
Fix NuGet push error by adding --skip-duplicate option

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Publish tool
       if: github.event_name != 'pull_request'
-      run: dotnet nuget push ./nupkg/*.nupkg  -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+      run: dotnet nuget push ./nupkg/*.nupkg  -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Create GitHub release
       if: github.event_name != 'pull_request'


### PR DESCRIPTION
Add `--skip-duplicate` option to the `dotnet nuget push` command in the GitHub workflow file to resolve error 409 (Conflict) when pushing the package.

* Modify `.github/workflows/build-and-test.yml` to include `--skip-duplicate` option in the `dotnet nuget push` command in the `Publish tool` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaq316/ContainerTagRemover/pull/20?shareId=88a72204-5be7-466e-bc44-61b4d656627f).