### PR TITLE
Ensure that published nuget package has the Full SemVer version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,12 @@ jobs:
       run: dotnet tool install -g GitVersion.Tool
 
     - name: Use GitVersion to generate version
+      id: gitversion
       run: dotnet-gitversion /output json /showvariable FullSemVer
+
+    - name: Set FullSemVer in ContainerTagRemover.csproj
+      run: |
+        sed -i 's/<Version>.*<\/Version>/<Version>${{ steps.gitversion.outputs.FullSemVer }}<\/Version>/' src/ContainerTagRemover/ContainerTagRemover.csproj
 
     - name: Restore dependencies
       run: dotnet restore src/ContainerTagRemover/ContainerTagRemover.sln
@@ -39,7 +44,7 @@ jobs:
       run: dotnet test src/ContainerTagRemover/ContainerTagRemover.sln --no-build --verbosity normal
 
     - name: Package tool
-      run: dotnet pack src/ContainerTagRemover/ContainerTagRemover.csproj --output ./nupkg
+      run: dotnet pack src/ContainerTagRemover/ContainerTagRemover.csproj --output ./nupkg --version-suffix ${{ steps.gitversion.outputs.FullSemVer }}
 
     - name: Publish tool
       if: github.event_name != 'pull_request'


### PR DESCRIPTION
Update GitHub workflow to include Full SemVer version in NuGet package.

* Add a step to set the Full SemVer version in `ContainerTagRemover.csproj` file.
* Update `dotnet pack` command to use the `--version-suffix` option with the Full SemVer version.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaq316/ContainerTagRemover/pull/21?shareId=c98a8ea1-80e7-4780-a1d9-ade5c877fed4).