### PR TITLE
Replace gitreleasemanager with actions/create-release

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,9 +50,11 @@ jobs:
 
     - name: Create GitHub release
       if: github.event_name != 'pull_request'
-      uses: gittools/actions/gitreleasemanager/create@v3.1.1
+      uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        name: ${{ steps.gitversion.outputs.FullSemVer }}
+        tag_name: ${{ steps.gitversion.outputs.FullSemVer }}
+        release_name: Release ${{ steps.gitversion.outputs.FullSemVer }}
+        body: |
+          Release notes for ${{ steps.gitversion.outputs.FullSemVer }}

--- a/README.md
+++ b/README.md
@@ -124,21 +124,20 @@ If any of the required arguments are not provided, the tool will prompt you to e
 
 This project uses GitVersion to generate release versions. GitVersion is a tool that generates version numbers based on your Git history. It follows Semantic Versioning (SemVer) principles and can be configured to suit your versioning strategy.
 
+## GitHub Release Generation
 
-## GitRelease Manager
-
-This project now uses GitRelease Manager to create GitHub Releases. GitRelease Manager is a tool that helps you manage your GitHub releases by automating the creation and updating of release notes.
+This project now uses the `actions/create-release@v1` action to create GitHub Releases. This action helps you manage your GitHub releases by automating the creation and updating of release notes.
 
 ### Release Generation Process
 
 1. Whenever the main branch is updated, the GitHub workflow will trigger the release generation process.
 2. GitVersion will be used to determine the version number based on the commit history.
-3. GitRelease Manager will be used to create a new release with the generated version number.
+3. The `actions/create-release@v1` action will be used to create a new release with the generated version number.
 
 ### Configuration
 
-The GitRelease Manager configuration file is included in the repository and can be customized to fit your release management strategy. For more information on configuring GitRelease Manager, refer to the [GitRelease Manager documentation](https://github.com/GitTools/actions/blob/main/docs/examples/github/gitreleasemanager/index.md).
+The configuration for the `actions/create-release@v1` action is included in the GitHub workflow file and can be customized to fit your release management strategy. For more information on configuring the `actions/create-release@v1` action, refer to the [GitHub Actions documentation](https://github.com/actions/create-release).
 
 ### GitHub Workflow
 
-The GitHub workflow file (`.github/workflows/build-and-test.yml`) has been updated to include steps for installing and using GitRelease Manager to generate release versions. The workflow will automatically create a new release whenever the main branch is updated. The `Create GitHub release` step now uses `gittools/actions/gitreleasemanager@v1` to create the release.
+The GitHub workflow file (`.github/workflows/build-and-test.yml`) has been updated to include steps for installing and using the `actions/create-release@v1` action to generate release versions. The workflow will automatically create a new release whenever the main branch is updated. The `Create GitHub release` step now uses `actions/create-release@v1` to create the release.


### PR DESCRIPTION
Update GitHub workflow and README to use `actions/create-release@v1` for creating GitHub releases.

* **README.md**
  - Update the section mentioning GitRelease Manager to reflect the change to `actions/create-release@v1`.
  - Modify the release generation process description to use `actions/create-release@v1`.
  - Update the configuration details to refer to the `actions/create-release@v1` action.

* **.github/workflows/build-and-test.yml**
  - Replace `gittools/actions/gitreleasemanager/create@v3.1.1` with `actions/create-release@v1` in the `Create GitHub release` step.
  - Update the `with` section to include `tag_name`, `release_name`, and `body`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaq316/ContainerTagRemover/pull/24?shareId=a1ba75cf-23f4-47cc-8680-fe5808198e70).