### PR TITLE
Mark DockerHub implementation as experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Container Tag Remover is a .NET tool written in C# to remove old image tags from
 
 ## Features
 
-- Supports Dockerhub and Azure Container Registry
+- Supports Dockerhub (experimental) and Azure Container Registry
 - Easily extensible to support new container registries
 - Removes old image tags based on SemVer and configuration file
 - Follows SOLID principles
@@ -35,6 +35,8 @@ To authenticate with Dockerhub and Azure Container Registry, you need to set the
 
 * `DOCKERHUB_USERNAME`: Your Dockerhub username.
 * `DOCKERHUB_PASSWORD`: Your Dockerhub password.
+
+Note: Dockerhub implementation is experimental.
 
 Example:
 

--- a/docs/GitHubRelease.md
+++ b/docs/GitHubRelease.md
@@ -9,6 +9,8 @@ The GitHub release generation process involves the following steps:
 5. Publish the tool to NuGet.
 6. Create a GitHub release.
 
+Note: DockerHub implementation is experimental.
+
 These steps are automated using GitHub Actions. The workflow file `.github/workflows/build-and-test.yml` defines the steps to build, test, package, and publish the tool, as well as create a GitHub release.
 
 ## GitHub Actions Workflow

--- a/docs/GitVersion.md
+++ b/docs/GitVersion.md
@@ -31,6 +31,8 @@ The release generation process involves the following steps:
 5. Publish the tool to NuGet.
 6. Create a GitHub release.
 
+Note: DockerHub implementation is experimental.
+
 These steps are automated using GitHub Actions. The workflow file `.github/workflows/build-and-test.yml` defines the steps to build, test, package, and publish the tool, as well as create a GitHub release.
 
 ### GitHub Actions Workflow

--- a/docs/InstallingTool.md
+++ b/docs/InstallingTool.md
@@ -19,3 +19,5 @@ containertagremover --version
 ```
 
 You should see the version number of the installed tool.
+
+Note: DockerHub implementation is experimental.

--- a/docs/RunningTests.md
+++ b/docs/RunningTests.md
@@ -16,6 +16,8 @@ dotnet test
 
 This will run all the tests in the `ContainerTagRemover.Tests` project and display the test results in the terminal or command prompt.
 
+Note: DockerHub implementation is experimental.
+
 ## Test Frameworks and Libraries
 
 The Container Tag Remover tool uses the following test frameworks and libraries:

--- a/docs/UsingTool.md
+++ b/docs/UsingTool.md
@@ -12,6 +12,8 @@ containertagremover <registry-url> <image> <config-file> [--output-file <output-
 
 Replace `<registry-url>`, `<image>`, and `<config-file>` with the appropriate values. Optionally, specify `<output-file>` to output the list of removed and kept tags to a JSON file.
 
+Note: DockerHub implementation is experimental.
+
 3. The tool will prompt you to enter any missing arguments during execution.
 
 4. The tool will authenticate with the specified container registry and remove old image tags based on the configuration file.


### PR DESCRIPTION
Mark the DockerHub implementation as experimental in all relevant markdown files.

* **README.md**
  - Mark DockerHub implementation as experimental in the "Features" section.
  - Add a note about DockerHub implementation being experimental in the "Environment Variables" section.

* **docs/UsingTool.md**
  - Add a note about DockerHub implementation being experimental in the usage instructions.

* **docs/InstallingTool.md**
  - Add a note about DockerHub implementation being experimental in the installation instructions.

* **docs/RunningTests.md**
  - Add a note about DockerHub implementation being experimental in the test instructions.

* **docs/GitHubRelease.md**
  - Add a note about DockerHub implementation being experimental in the release generation process.

* **docs/GitVersion.md**
  - Add a note about DockerHub implementation being experimental in the release generation process.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaq316/ContainerTagRemover/pull/27?shareId=0881b29a-0f19-45a8-8634-dbbd3896e0c0).