### PR TITLE
Prevent GitHub workflow from executing on changes to docs folder

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   build-and-test:

--- a/docs/GitHubRelease.md
+++ b/docs/GitHubRelease.md
@@ -29,3 +29,5 @@ The GitHub Actions workflow file `.github/workflows/build-and-test.yml` includes
 10. Create a GitHub release (if not a pull request).
 
 The workflow is triggered on pushes to the `main` branch and on pull requests targeting the `main` branch.
+
+Note: The GitHub workflow now prevents execution on changes to the `docs` folder and its contents.

--- a/docs/GitVersion.md
+++ b/docs/GitVersion.md
@@ -51,3 +51,5 @@ The GitHub Actions workflow file `.github/workflows/build-and-test.yml` includes
 10. Create a GitHub release (if not a pull request).
 
 The workflow is triggered on pushes to the `main` branch and on pull requests targeting the `main` branch.
+
+Note: The GitHub workflow now prevents execution on changes to the `docs` folder and its contents.

--- a/docs/GitVersionBranchingStrategy.md
+++ b/docs/GitVersionBranchingStrategy.md
@@ -59,3 +59,5 @@ The GitHub Actions workflow file `.github/workflows/build-and-test.yml` includes
 10. Create a GitHub release (if not a pull request).
 
 The workflow is triggered on pushes to the `main` branch and on pull requests targeting the `main` branch.
+
+Note: The GitHub workflow now prevents execution on changes to the `docs` folder and its contents.

--- a/docs/RunningTests.md
+++ b/docs/RunningTests.md
@@ -37,3 +37,5 @@ dotnet test --collect:"XPlat Code Coverage"
 ```
 
 The code coverage report will be generated in the `TestResults` directory in the project root. You can open the `coverage.cobertura.xml` file in a code coverage visualization tool to view the detailed code coverage report.
+
+Note: The GitHub workflow now prevents execution on changes to the `docs` folder and its contents.


### PR DESCRIPTION
Update GitHub workflow to prevent execution on changes to the `docs` folder and its contents.

* Modify `.github/workflows/build-and-test.yml` to add a `paths-ignore` section under `on` for both `push` and `pull_request` events, excluding changes to the `docs` folder.
* Add a note in `docs/GitHubRelease.md`, `docs/GitVersion.md`, `docs/GitVersionBranchingStrategy.md`, and `docs/RunningTests.md` indicating that the GitHub workflow now prevents execution on changes to the `docs` folder and its contents.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaq316/ContainerTagRemover/pull/33?shareId=5d6a4fd9-0d09-43f2-a2c3-9c54494a53e4).