### PR TITLE
Update tag removal logic to filter major and minor versions

### DIFF
--- a/src/ContainerTagRemover/Services/TagRemovalService.cs
+++ b/src/ContainerTagRemover/Services/TagRemovalService.cs
@@ -56,7 +56,7 @@ namespace ContainerTagRemover.Services
             // Then filter out only the latest number of minor versions for each major version
             var latestMinorVersions = latestMajorVersions
                 .GroupBy(v => new { v.Major, v.Minor })
-                .SelectMany(g => g.OrderByDescending(v => v).Take(config.Minor))
+                .SelectMany(g => g.OrderByDescending(v => v, new VersionComparer()).Take(config.Minor))
                 .ToList();
 
             tagsToKeep.UnionWith(latestMinorVersions);

--- a/src/ContainerTagRemover/Services/TagRemovalService.cs
+++ b/src/ContainerTagRemover/Services/TagRemovalService.cs
@@ -45,20 +45,23 @@ namespace ContainerTagRemover.Services
 
             var tagsToKeep = new HashSet<SemVersion>();
 
-            KeepLatestVersions(semverTags, tagsToKeep, config.Major, v => v.Major);
-            KeepLatestVersions(semverTags, tagsToKeep, config.Minor, v => (v.Major, v.Minor));
+            // First filter the major versions to only include the latest number of major versions as configured
+            var latestMajorVersions = semverTags
+                .GroupBy(v => v.Major)
+                .OrderByDescending(g => g.Key)
+                .Take(config.Major)
+                .SelectMany(g => g)
+                .ToList();
+
+            // Then filter out only the latest number of minor versions for each major version
+            var latestMinorVersions = latestMajorVersions
+                .GroupBy(v => new { v.Major, v.Minor })
+                .SelectMany(g => g.OrderByDescending(v => v).Take(config.Minor))
+                .ToList();
+
+            tagsToKeep.UnionWith(latestMinorVersions);
 
             return semverTags.Where(v => !tagsToKeep.Any(t => t.ToString() == v.ToString())).Select(v => v.ToString());
-        }
-
-        private static void KeepLatestVersions<T>(List<SemVersion> semverTags, HashSet<SemVersion> tagsToKeep, int count, Func<SemVersion, T> keySelector)
-        {
-            var groupedTags = semverTags.GroupBy(keySelector);
-
-            foreach (var group in groupedTags)
-            {
-                tagsToKeep.UnionWith(group.Take(count));
-            }
         }
 
         public virtual List<string> GetRemovedTags()

--- a/tests/ContainerTagRemover.Tests/Services/TagRemovalServiceTests.cs
+++ b/tests/ContainerTagRemover.Tests/Services/TagRemovalServiceTests.cs
@@ -177,6 +177,56 @@ namespace ContainerTagRemover.Tests.Services
         }
 
         [Fact]
+        public void DetermineTagsToRemove_Should_Filter_Latest_Major_Versions()
+        {
+            // Arrange
+            var tags = new List<string> {
+                "1.0.0",
+                "1.1.0",
+                "2.0.0",
+                "2.1.0",
+                "3.0.0",
+                "3.1.0",
+                "4.0.0",
+                "4.1.0",
+            };
+
+            // Act
+            var result = _tagRemovalService.DetermineTagsToRemove(tags);
+
+            // Assert
+            result.ShouldNotContain("3.0.0");
+            result.ShouldNotContain("3.1.0");
+            result.ShouldNotContain("4.0.0");
+            result.ShouldNotContain("4.1.0");
+        }
+
+        [Fact]
+        public void DetermineTagsToRemove_Should_Filter_Latest_Minor_Versions_For_Each_Major_Version()
+        {
+            // Arrange
+            var tags = new List<string> {
+                "1.0.0",
+                "1.1.0",
+                "2.0.0",
+                "2.1.0",
+                "3.0.0",
+                "3.1.0",
+                "4.0.0",
+                "4.1.0",
+                "4.2.0",
+                "4.3.0",
+            };
+
+            // Act
+            var result = _tagRemovalService.DetermineTagsToRemove(tags);
+
+            // Assert
+            result.ShouldNotContain("4.2.0");
+            result.ShouldNotContain("4.3.0");
+        }
+
+        [Fact]
         public void GetRemovedTags_Should_Return_Correct_List()
         {
             // Arrange


### PR DESCRIPTION
Update the `DetermineTagsToRemove` method in `TagRemovalService.cs` to filter tags based on the latest major and minor versions as configured.

* Filter the major versions to only include the latest number of major versions as configured.
* Filter out only the latest number of minor versions for each major version.
* Add test cases in `TagRemovalServiceTests.cs` to verify the filtering of the latest major and minor versions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaq316/ContainerTagRemover/pull/36?shareId=a5230197-0d7b-4a6b-8b6a-f951a065829e).