### PR TITLE
Refactor TagRemovalService and update tests

### DIFF
--- a/src/ContainerTagRemover/Services/TagRemovalService.cs
+++ b/src/ContainerTagRemover/Services/TagRemovalService.cs
@@ -54,9 +54,12 @@ namespace ContainerTagRemover.Services
                 .ToList();
 
             // Then filter out only the latest number of minor versions for each major version
+
             var latestMinorVersions = latestMajorVersions
-                .GroupBy(v => new { v.Major, v.Minor })
-                .SelectMany(g => g.OrderByDescending(v => v, new VersionComparer()).Take(config.Minor))
+                .GroupBy(v => v.Major)
+                .Select(g => new { Major = g.Key, Versions = g.Select(v => v) })
+                .Select(g => g.Versions.OrderByDescending(v => v, new VersionComparer()).Take(config.Minor))
+                .SelectMany(v => v)
                 .ToList();
 
             tagsToKeep.UnionWith(latestMinorVersions);

--- a/tests/ContainerTagRemover.Tests/Services/TagRemovalServiceTests.cs
+++ b/tests/ContainerTagRemover.Tests/Services/TagRemovalServiceTests.cs
@@ -3,6 +3,7 @@ using ContainerTagRemover.Interfaces;
 using ContainerTagRemover.Services;
 using Moq;
 using Shouldly;
+using Xunit.Sdk;
 
 namespace ContainerTagRemover.Tests.Services
 {
@@ -30,38 +31,38 @@ namespace ContainerTagRemover.Tests.Services
             // Arrange
             var repository = "test-repo";
             var tags = new List<Tag> {
-                new Tag("1.0.0", "digest1"),
-                new Tag("1.0.1", "digest2"),
-                new Tag("1.0.2", "digest3"),
-                new Tag("1.0.3", "digest4"),
-                new Tag("1.0.4", "digest5"),
-                new Tag("1.0.5", "digest6"),
-                new Tag("1.0.6", "digest7"),
-                new Tag("1.0.7", "digest8"),
-                new Tag("1.1.0", "digest9"),
-                new Tag("1.1.1", "digest10"),
-                new Tag("1.1.2", "digest11"),
-                new Tag("1.1.3", "digest12"),
-                new Tag("1.1.4", "digest13"),
-                new Tag("1.1.5", "digest14"),
-                new Tag("1.1.6", "digest15"),
-                new Tag("1.1.7", "digest16"),
-                new Tag("2.0.0", "digest17"),
-                new Tag("2.0.1", "digest18"),
-                new Tag("2.0.2", "digest19"),
-                new Tag("2.0.3", "digest20"),
-                new Tag("2.0.4", "digest21"),
-                new Tag("2.0.5", "digest22"),
-                new Tag("2.0.6", "digest23"),
-                new Tag("2.0.7", "digest24"),
-                new Tag("2.1.0", "digest25"),
-                new Tag("2.1.1", "digest26"),
-                new Tag("2.1.2", "digest27"),
-                new Tag("2.1.3", "digest28"),
-                new Tag("2.1.4", "digest29"),
-                new Tag("2.1.5", "digest30"),
-                new Tag("2.1.6", "digest31"),
-                new Tag("2.1.7", "digest32"),
+                new("1.0.0", "digest1"),
+                new("1.0.1", "digest2"),
+                new("1.0.2", "digest3"),
+                new("1.0.3", "digest4"),
+                new("1.0.4", "digest5"),
+                new("1.0.5", "digest6"),
+                new("1.0.6", "digest7"),
+                new("1.0.7", "digest8"),
+                new("1.1.0", "digest9"),
+                new("1.1.1", "digest10"),
+                new("1.1.2", "digest11"),
+                new("1.1.3", "digest12"),
+                new("1.1.4", "digest13"),
+                new("1.1.5", "digest14"),
+                new("1.1.6", "digest15"),
+                new("1.1.7", "digest16"),
+                new("2.0.0", "digest17"),
+                new("2.0.1", "digest18"),
+                new("2.0.2", "digest19"),
+                new("2.0.3", "digest20"),
+                new("2.0.4", "digest21"),
+                new("2.0.5", "digest22"),
+                new("2.0.6", "digest23"),
+                new("2.0.7", "digest24"),
+                new("2.1.0", "digest25"),
+                new("2.1.1", "digest26"),
+                new("2.1.2", "digest27"),
+                new("2.1.3", "digest28"),
+                new("2.1.4", "digest29"),
+                new("2.1.5", "digest30"),
+                new("2.1.6", "digest31"),
+                new("2.1.7", "digest32"),
             };
             _mockRegistryClient.Setup(x => x.ListTagsAsync(repository)).ReturnsAsync(tags);
 
@@ -75,8 +76,8 @@ namespace ContainerTagRemover.Tests.Services
             _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "1.0.3"), Times.Once);
             _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "1.0.4"), Times.Once);
             _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "1.0.5"), Times.Once);
-            _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "1.0.6"), Times.Never);
-            _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "1.0.7"), Times.Never);
+            _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "1.0.6"), Times.Once);
+            _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "1.0.7"), Times.Once);
 
             _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "1.0.1"), Times.Once);
             _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "1.1.0"), Times.Once);
@@ -94,8 +95,8 @@ namespace ContainerTagRemover.Tests.Services
             _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "2.0.3"), Times.Once);
             _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "2.0.4"), Times.Once);
             _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "2.0.5"), Times.Once);
-            _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "2.0.6"), Times.Never);
-            _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "2.0.7"), Times.Never);
+            _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "2.0.6"), Times.Once);
+            _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "2.0.7"), Times.Once);
 
             _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "2.1.0"), Times.Once);
             _mockRegistryClient.Verify(x => x.DeleteTagAsync(repository, "2.1.1"), Times.Once);
@@ -111,17 +112,17 @@ namespace ContainerTagRemover.Tests.Services
         public void DetermineTagsToRemove_Should_Return_Correct_Tags()
         {
             // Arrange
-            var tags = new List<string> { 
-                "1.0.0", 
-                "1.0.1", 
+            var tags = new List<string> {
+                "1.0.0",
+                "1.0.1",
                 "1.0.2",
                 "1.0.3",
                 "1.0.4",
                 "1.0.5",
                 "1.0.6",
                 "1.0.7",
-                "1.1.0", 
-                "1.1.1", 
+                "1.1.0",
+                "1.1.1",
                 "1.1.2",
                 "1.1.3",
                 "1.1.4",
@@ -227,24 +228,24 @@ namespace ContainerTagRemover.Tests.Services
         }
 
         [Fact]
-        public void GetRemovedTags_Should_Return_Correct_List()
+        public async Task GetRemovedTags_Should_Return_Correct_List()
         {
             // Arrange
             var repository = "test-repo";
             var tags = new List<Tag> {
-                new Tag("1.0.0", "digest1"),
-                new Tag("1.0.1", "digest2"),
-                new Tag("1.0.2", "digest3"),
-                new Tag("1.0.3", "digest4"),
-                new Tag("1.0.4", "digest5"),
-                new Tag("1.0.5", "digest6"),
-                new Tag("1.0.6", "digest7"),
-                new Tag("1.0.7", "digest8"),
+                new("1.0.0", "digest1"),
+                new("1.0.1", "digest2"),
+                new("1.0.2", "digest3"),
+                new("1.0.3", "digest4"),
+                new("1.0.4", "digest5"),
+                new("1.0.5", "digest6"),
+                new("1.0.6", "digest7"),
+                new("1.0.7", "digest8"),
             };
             _mockRegistryClient.Setup(x => x.ListTagsAsync(repository)).ReturnsAsync(tags);
 
             // Act
-            _tagRemovalService.RemoveOldTagsAsync(repository).Wait();
+            await _tagRemovalService.RemoveOldTagsAsync(repository);
             var removedTags = _tagRemovalService.GetRemovedTags();
 
             // Assert
@@ -257,29 +258,53 @@ namespace ContainerTagRemover.Tests.Services
         }
 
         [Fact]
-        public void GetKeptTags_Should_Return_Correct_List()
+        public async Task GetKeptTags_Should_Return_Correct_List()
         {
             // Arrange
             var repository = "test-repo";
             var tags = new List<Tag> {
-                new Tag("1.0.0", "digest1"),
-                new Tag("1.0.1", "digest2"),
-                new Tag("1.0.2", "digest3"),
-                new Tag("1.0.3", "digest4"),
-                new Tag("1.0.4", "digest5"),
-                new Tag("1.0.5", "digest6"),
-                new Tag("1.0.6", "digest7"),
-                new Tag("1.0.7", "digest8"),
+                new ("2.0.1-alpha.0","digest"),
+                new ("2.0.0-alpha.0","digest"),
+                new ("1.22.0-alpha.0","digest"),
+                new ("1.21.0-alpha.82","digest"),
+                new ("1.21.0-alpha.62","digest"),
+                new ("1.20.0-alpha.15","digest"),
+                new ("1.20.0-alpha.7","digest"),
+                new ("1.19.0-alpha.57","digest"),
+                new ("1.19.0-alpha.56","digest"),
+                new ("1.18.0-bugfix-infrastructure-ca-portmappings.1-2","digest"),
+                new ("1.18.0-fix-messagebus.1-20","digest"),
+                new ("1.17.0-alpha.28","digest"),
+                new ("1.17.0-alpha.27","digest"),
+                new ("1.16.0-alpha.92","digest"),
+                new ("1.16.0-alpha.91","digest"),
+                new ("1.15.0-alpha.10","digest"),
+                new ("1.15.0-alpha.9","digest")
             };
             _mockRegistryClient.Setup(x => x.ListTagsAsync(repository)).ReturnsAsync(tags);
 
             // Act
-            _tagRemovalService.RemoveOldTagsAsync(repository).Wait();
+            await _tagRemovalService.RemoveOldTagsAsync(repository);
             var keptTags = _tagRemovalService.GetKeptTags();
 
             // Assert
-            keptTags.ShouldContain("1.0.6");
-            keptTags.ShouldContain("1.0.7");
+            keptTags.ShouldContain("2.0.1-alpha.0");
+            keptTags.ShouldContain("2.0.0-alpha.0");
+            keptTags.ShouldContain("1.22.0-alpha.0");
+            keptTags.ShouldContain("1.21.0-alpha.82");
+            keptTags.ShouldNotContain("1.21.0-alpha.62");
+            keptTags.ShouldNotContain("1.20.0-alpha.15");
+            keptTags.ShouldNotContain("1.20.0-alpha.7");
+            keptTags.ShouldNotContain("1.19.0-alpha.57");
+            keptTags.ShouldNotContain("1.19.0-alpha.56");
+            keptTags.ShouldNotContain("1.18.0-bugfix-infrastructure-ca-portmappings.1-2");
+            keptTags.ShouldNotContain("1.18.0-fix-messagebus.1-20");
+            keptTags.ShouldNotContain("1.17.0-alpha.28");
+            keptTags.ShouldNotContain("1.17.0-alpha.27");
+            keptTags.ShouldNotContain("1.16.0-alpha.92");
+            keptTags.ShouldNotContain("1.16.0-alpha.91");
+            keptTags.ShouldNotContain("1.15.0-alpha.10");
+            keptTags.ShouldNotContain("1.15.0-alpha.9");
         }
     }
 }


### PR DESCRIPTION
Refactor TagRemovalService and update tests

Refactored TagRemovalService to improve filtering logic for latest minor versions by grouping by major version and ordering by version. Updated TagRemovalServiceTests to include new using statement, concise list initialization, and modified assertions. Made test methods asynchronous and updated test data and assertions for GetKeptTags_Should_Return_Correct_List.